### PR TITLE
Change the default ecc key size to 256 and fix the KEY_SIZE parameter for ECC

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Please note:
 | `LEGO_KUBE_ANNOTATION` | n | `kubernetes.io/tls-acme` | Set the ingress annotation used by this instance of kube-lego to get certificate for from Let's Encrypt. Allows you to run kube-lego against staging and production LE |
 | `LEGO_WATCH_NAMESPACE` | n | `` | Namespace that kube-lego should watch for ingresses and services |
 | `LEGO_KEY_TYPE` | n | `ecc` | Set your preferred private key type (`ecc`, `rsa`) to generate certificates with. |
-| `LEGO_KEY_SIZE` | n | `ecc`: `384` <br><br>`rsa`: `2048` |  Set your preferred key size based on the key type selected. <br><br>For `ecc` keys, you may select curves (`224`, `256`, `384`, `521`) , `384` being the default. <br><br>For `rsa` keys, you may provide a reasonable size, `2048` being the default. |
+| `LEGO_KEY_SIZE` | n | `ecc`: `256` <br><br>`rsa`: `2048` |  Set your preferred key size based on the key type selected. <br><br>For `ecc` keys, you may select curves (`224`, `256`, `384`, `521`) , `256` being the default. <br><br>For `rsa` keys, you may provide a reasonable size, `2048` being the default. |
 
 ## Full deployment examples
 

--- a/pkg/kubelego/kubelego.go
+++ b/pkg/kubelego/kubelego.go
@@ -366,8 +366,11 @@ func (kl *KubeLego) paramsLego() error {
 	if keyType == kubelego.KeyTypeEcc {
 		switch keySize {
 		case "224":
+			fallthrough
 		case "256":
+			fallthrough
 		case "384":
+			fallthrough
 		case "521":
 			ks, err := strconv.ParseInt(keySize, 10, 0)
 			if err != nil {

--- a/pkg/kubelego_const/consts.go
+++ b/pkg/kubelego_const/consts.go
@@ -8,7 +8,7 @@ const KeyTypeRsa = "rsa"
 const RsaKeySize = 2048
 
 const KeyTypeEcc = "ecc"
-const EccKeySize = 384
+const EccKeySize = 256
 
 const AcmeRegistration = "acme-registration.json"
 const AcmeRegistrationUrl = "acme-registration-url"


### PR DESCRIPTION
A default key size of 384 puts a higher load than necessary on the http server and the key_size is only parsed for 521 key sizes